### PR TITLE
Complete with 'foo(' instead of 'foo' / 'foo()'

### DIFF
--- a/tests/test_jedi.py
+++ b/tests/test_jedi.py
@@ -118,8 +118,8 @@ def test_multiline(jedi_xontrib, jedi_mock, monkeypatch):
                 ("function", "def __get__"),
             ),
             RichCompletion(
-                "from_bytes",
-                display="from_bytes()",
+                "from_bytes(",
+                display="from_bytes(",
                 description="from_bytes(bytes, byteorder, *, signed=False)",
             ),
         ),

--- a/xontrib/jedi.py
+++ b/xontrib/jedi.py
@@ -125,14 +125,14 @@ def create_completion(comp: jedi.api.classes.Completion):
             comp_type = inf[0].type
             description = inf[0].description
 
-    display = comp.name + ("()" if comp_type == "function" else "")
+    completion = comp.name + ("(" if comp_type == "function" else "")
     description = description or comp.type
 
     prefix_len = len(comp.name) - len(comp.complete)
 
     return RichCompletion(
-        comp.name,
-        display=display,
+        completion,
+        display=completion,
         description=description,
         prefix_len=prefix_len,
     )


### PR DESCRIPTION
Xonsh's base completer, which is used in simple expressions even with jedi loaded, completes method names with the opening parenthesis only, and displays the list as such.

```xsh
@ "".ca<TAB>
#  capitalize(    casefold(
```

Whereas currently this xontrib displays `capitalize()    casefold()`, then completes `capitalize` without any parenthesis. I wonder if this was matching former Xonsh behavior that was since updated.

This PR would make behavior consistent between base- and jedi-provided completions in xonsh python code.

I also think it is good behavior. When one completes on a method, one usually want to call it, so opening the parenthesis lets one enter parameters or close it.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**